### PR TITLE
make fpga reset optional

### DIFF
--- a/rfdev.c
+++ b/rfdev.c
@@ -981,7 +981,10 @@ static int rfdev_remove(struct i2c_client *client)
 
 	pr_debug("%s: remove\n", DEV_NAME);
 
+	#ifdef RESET_FPGA
 	reset_fpga(rfdev);
+	#endif
+	
 	fpga_mgr_unregister(rfdev->mgr);
 	misc_deregister(&rfdev->miscdev);
 	return 0;


### PR DESCRIPTION
As discussed, it would be better If we made reset_fpga() optional as we need the JTAG interface for communication with the fabric after programming the MachXO2. It would be better if we gave it as a command line option